### PR TITLE
Skip old releases when scraping

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sh-semver"]
+	path = lib/sh-semver
+	url = https://github.com/qzb/sh-semver

--- a/bin/rbenv-update-version-defs
+++ b/bin/rbenv-update-version-defs
@@ -74,9 +74,17 @@ while [ $# -gt 0 ]; do
     -h | --help )
       exec rbenv-help update-version-defs ;;
     -f | --force | \
-    -n | --dry-run | \
-    --cruby | --rubinius )
+    -n | --dry-run )
       SCRAPE_OPTS[${#SCRAPE_OPTS[*]}]="$1" ;;
+    --cruby | --rubinius )
+      SCRAPE_OPTS[${#SCRAPE_OPTS[*]}]="$1"
+
+      # check for optional version filter
+      if [ -n "$2" ] && [ "$2" = "${2#-}" ]; then
+        SCRAPE_OPTS[${#SCRAPE_OPTS[*]}]="$2"
+        shift
+      fi
+      ;;
     * )
       rbenv-help --usage update-version-defs >&2
       exit 1;;

--- a/lib/scrape_cruby.bash
+++ b/lib/scrape_cruby.bash
@@ -1,22 +1,23 @@
 MANIFEST=https://cache.ruby-lang.org/pub/ruby/index.txt
 
 scrape_cruby() {
-  local line release version filename url sha
+  local line release version filename package url sha
 
   curl -qsSLf "$MANIFEST" | grep '.tar.bz2' |\
   while IFS='' read -r line || [[ -n "$line" ]]; do
     read -ra release <<<"$line"
 
-    version="${release[0]}"
-    filename="${version#ruby-}"
+    package="${release[0]}"
     url="${release[1]}"
     sha="${release[3]}"
 
-    if ! file_exists "$filename" && is_recent_release "$filename"; then
-      write_file "$filename" <<DEF
+    version="${package#ruby-}"
+    filename="$version"
+
+    generate_definition "$version" "$filename" <<DEFINITION
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
-install_package "$version" "$url#$sha" ldflags_dirs standard verify_openssl
-DEF
-    fi
+install_package "$package" "$url#$sha" ldflags_dirs standard verify_openssl
+DEFINITION
+
   done
 }

--- a/lib/scrape_cruby.bash
+++ b/lib/scrape_cruby.bash
@@ -12,7 +12,7 @@ scrape_cruby() {
     url="${release[1]}"
     sha="${release[3]}"
 
-    if ! file_exists "$filename"; then
+    if ! file_exists "$filename" && is_recent_release "$filename"; then
       write_file "$filename" <<DEF
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "$version" "$url#$sha" ldflags_dirs standard verify_openssl

--- a/libexec/scrape
+++ b/libexec/scrape
@@ -5,8 +5,15 @@ declare -A VERSION_FILTERS
 
 push_engine() {
   local engine="$1"
+  [ "$2" = "${2#-}" ] && local version_filter="$2"
 
   RUBIES+=("$engine")
+  if [ -n "$version_filter" ]; then
+    VERSION_FILTERS["$engine"]="$version_filter"
+
+    # signal that a version filter was provided and needs shifted
+    return 1
+  fi
 }
 
 while [ $# -gt 0 ]; do
@@ -16,9 +23,9 @@ while [ $# -gt 0 ]; do
     -n | --dry-run )
       DRY_RUN=true ;;
     --cruby )
-      push_engine cruby ;;
+      push_engine cruby "$2" || shift ;;
     --rbx | --rubinius )
-      push_engine rubinius ;;
+      push_engine rubinius "$2" || shift ;;
     * )
       echo "invalid usage" >&2
       exit 1 ;;

--- a/libexec/scrape
+++ b/libexec/scrape
@@ -37,6 +37,12 @@ IFS=: read -ra DEF_PATHS <<<"${RUBY_BUILD_DEFINITIONS:-share/ruby-build}"
 
 [ ${#RUBIES[@]} -gt 0 ] || RUBIES=(cruby rubinius)
 
+is_recent_release() {
+  local version="$1"
+
+  test "${VERSION_FILTERS[$RUBY_ENGINE]}" \< "$version"
+}
+
 file_exists() {
   local filename="$1"
   [ -n "$OVERWRITE" ] && return 1

--- a/libexec/scrape
+++ b/libexec/scrape
@@ -37,12 +37,6 @@ IFS=: read -ra DEF_PATHS <<<"${RUBY_BUILD_DEFINITIONS:-share/ruby-build}"
 
 [ ${#RUBIES[@]} -gt 0 ] || RUBIES=(cruby rubinius)
 
-is_recent_release() {
-  local version="$1"
-
-  test -n "$(lib/sh-semver/semver.sh -r "${VERSION_FILTERS[$RUBY_ENGINE]}" "$version")"
-}
-
 file_exists() {
   local filename="$1"
   [ -n "$OVERWRITE" ] && return 1
@@ -50,6 +44,12 @@ file_exists() {
   for p in "${DEF_PATHS[@]}"; do
     [ -f "$p/$filename" ] && return
   done
+}
+
+is_recent_release() {
+  local version="$1"
+
+  test -n "$(lib/sh-semver/semver.sh -r "${VERSION_FILTERS[$RUBY_ENGINE]}" "$version")"
 }
 
 write_file() {

--- a/libexec/scrape
+++ b/libexec/scrape
@@ -49,7 +49,7 @@ file_exists() {
 is_recent_release() {
   local version="$1"
 
-  test -n "$(lib/sh-semver/semver.sh -r "${VERSION_FILTERS[$RUBY_ENGINE]}" "$version")"
+  test -n "$(lib/sh-semver/semver.sh -a -r "${VERSION_FILTERS[$RUBY_ENGINE]}" "$version")"
 }
 
 write_file() {

--- a/libexec/scrape
+++ b/libexec/scrape
@@ -1,6 +1,13 @@
 #! /usr/bin/env bash
 
 declare -a RUBIES
+declare -A VERSION_FILTERS
+
+push_engine() {
+  local engine="$1"
+
+  RUBIES+=("$engine")
+}
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -9,9 +16,9 @@ while [ $# -gt 0 ]; do
     -n | --dry-run )
       DRY_RUN=true ;;
     --cruby )
-      RUBIES+=('cruby') ;;
+      push_engine cruby ;;
     --rbx | --rubinius )
-      RUBIES+=('rubinius') ;;
+      push_engine rubinius ;;
     * )
       echo "invalid usage" >&2
       exit 1 ;;

--- a/libexec/scrape
+++ b/libexec/scrape
@@ -58,8 +58,8 @@ write_file() {
   fi
 }
 
-for ruby in "${RUBIES[@]}"; do
-  . "lib/scrape_${ruby}.bash"
+for RUBY_ENGINE in "${RUBIES[@]}"; do
+  . "lib/scrape_${RUBY_ENGINE}.bash"
 
-  scrape_"$ruby"
+  scrape_"$RUBY_ENGINE"
 done

--- a/libexec/scrape
+++ b/libexec/scrape
@@ -40,7 +40,7 @@ IFS=: read -ra DEF_PATHS <<<"${RUBY_BUILD_DEFINITIONS:-share/ruby-build}"
 is_recent_release() {
   local version="$1"
 
-  test "${VERSION_FILTERS[$RUBY_ENGINE]}" \< "$version"
+  test -n "$(lib/sh-semver/semver.sh -r "${VERSION_FILTERS[$RUBY_ENGINE]}" "$version")"
 }
 
 file_exists() {

--- a/libexec/scrape
+++ b/libexec/scrape
@@ -64,6 +64,16 @@ write_file() {
   fi
 }
 
+generate_definition() {
+  # definition contents on stdin
+  local version="$1"
+  local filename="$2"
+
+  if ! file_exists "$filename" && is_recent_release "$version"; then
+    write_file "$filename"
+  fi
+}
+
 for RUBY_ENGINE in "${RUBIES[@]}"; do
   . "lib/scrape_${RUBY_ENGINE}.bash"
 


### PR DESCRIPTION
This pr is mostly a spike to allow specifying a version before which no definition files will be created.

It's mostly working except it's filtering by using bash ascii sort order. So it's not numerical or semver compliant.
- [x] steal semver version ordering from rbenv-alias (actually using [sh-semver](https://github.com/qzb/sh-semver/pull/1) instead)
- [x] maybe refactor the file_exists+recent_release+write_file into a single function. (needs version string, filename, and definition contents)
